### PR TITLE
Force aws cli output to json to avoid errors if default output is changed

### DIFF
--- a/okta_aws
+++ b/okta_aws
@@ -147,7 +147,7 @@ class OktaAWS(object):
         # Get credentials from aws
         try:
             output = subprocess.check_output([
-                "aws", "sts", "assume-role-with-saml",
+                "aws", "--output", "json", "sts", "assume-role-with-saml",
                 "--role-arn", config['role_arn'],
                 "--principal-arn", config['principal_arn'],
                 "--saml-assertion", base64.b64encode(assertion)])


### PR DESCRIPTION
This currently assumes json output but uses whatever format is set in the aws cli.  To avoid errors the command should force the `--output json` option.

Signed-off-by: Paul Mooring <paul@chef.io>