### PR TITLE
Fixes error when session_id not already set.

### DIFF
--- a/okta_aws/okta_aws.py
+++ b/okta_aws/okta_aws.py
@@ -545,6 +545,8 @@ class OktaAWS(object):
                     session_id = None
             else:
                 session_id = None
+        else:
+            session_id = None
 
         if session_id is None:
             print("Okta Username:", self.get_config('username'))


### PR DESCRIPTION
Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>

Without this you'd get the following when using `-n`:

```
Traceback (most recent call last):
  File "/usr/local/bin/okta_aws", line 11, in <module>
    load_entry_point('okta-aws==0.5.1', 'console_scripts', 'okta_aws')()
  File "/usr/local/Cellar/okta_aws/0.5.1/libexec/lib/python3.6/site-packages/okta_aws/__main__.py", line 24, in main
    okta_aws.OktaAWS(args).run()
  File "/usr/local/Cellar/okta_aws/0.5.1/libexec/lib/python3.6/site-packages/okta_aws/okta_aws.py", line 549, in run
    if session_id is None:
UnboundLocalError: local variable 'session_id' referenced before assignment
```