### PR TITLE
Better error handling for aws_assume_role

### DIFF
--- a/okta_aws/exceptions.py
+++ b/okta_aws/exceptions.py
@@ -7,3 +7,9 @@ class LoginError(Error):
     "Error logging in to okta"
     def __init__(self, message):
         self.message = message
+
+
+class AssumeRoleError(Error):
+    "Error running aws assume-role-with-saml"
+    def __init__(self, message):
+        self.message = message

--- a/tests/test_aws_assume_role.py
+++ b/tests/test_aws_assume_role.py
@@ -1,4 +1,9 @@
 # pylint: disable=invalid-name,missing-docstring
+import pytest
+import subprocess
+
+from okta_aws import exceptions
+
 from unittest.mock import patch
 
 
@@ -30,3 +35,57 @@ def test_aws_assume_role(oa, shared_datadir):
             'ORIOv9SEpaRewDSX/wl74DVElH9VQ0fOHdsD6MNFnKl+NEAiYd4vZMjk1U8/e' \
             '4GAWZIF/EHaQxgHU3NBsWvRYsTQUPombgR81BXm9Quh9aj'
         assert credentials['Expiration'] == '2018-04-24T00:00:00Z'
+
+
+def test_aws_assume_role_no_output(oa, shared_datadir):
+    with patch("subprocess.check_output") as patched_check_output:
+        patched_check_output.return_value = b''
+
+        with pytest.raises(exceptions.AssumeRoleError,
+                           match="JSON decode error:"):
+            oa.aws_assume_role(
+                'arn:aws:iam::012345678901:saml-provider/OKTA',
+                'arn:aws:iam::012345678901:role/Okta_AdministratorAccess',
+                'fake_assertion',
+                3600)
+
+
+def test_aws_assume_role_no_credentials(oa, shared_datadir):
+    with patch("subprocess.check_output") as patched_check_output:
+        patched_check_output.return_value = b'{}'
+
+        with pytest.raises(exceptions.AssumeRoleError,
+                           match="Credentials key not in returned json"):
+            oa.aws_assume_role(
+                'arn:aws:iam::012345678901:saml-provider/OKTA',
+                'arn:aws:iam::012345678901:role/Okta_AdministratorAccess',
+                'fake_assertion',
+                3600)
+
+
+def test_aws_assume_role_no_awscli(oa, shared_datadir):
+    with patch("subprocess.check_output") as patched_check_output:
+        patched_check_output.side_effect = OSError(
+            2, 'No such file or directory: aws')
+
+        with pytest.raises(exceptions.AssumeRoleError,
+                           match="AWS CLI cannot be found"):
+            oa.aws_assume_role(
+                'arn:aws:iam::012345678901:saml-provider/OKTA',
+                'arn:aws:iam::012345678901:role/Okta_AdministratorAccess',
+                'fake_assertion',
+                3600)
+
+
+def test_aws_assume_role_awscli_failed(oa, shared_datadir):
+    with patch("subprocess.check_output") as patched_check_output:
+        patched_check_output.side_effect = subprocess.CalledProcessError(
+            1, 'some command')
+
+        with pytest.raises(exceptions.AssumeRoleError,
+                           match="aws command exited with 1"):
+            oa.aws_assume_role(
+                'arn:aws:iam::012345678901:saml-provider/OKTA',
+                'arn:aws:iam::012345678901:role/Okta_AdministratorAccess',
+                'fake_assertion',
+                3600)


### PR DESCRIPTION
Similar treatment as for log_into_okta with a custom exception and catching
more error conditions. Tests are added for the various conditions also.