### PR TITLE
Use boto3 to get temporary credentials to bypass windows cmd issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,5 @@ setup(
     python_requires='>=3',
     setup_requires=['pytest-runner'],
     tests_require=['pytest', 'pytest_datadir'],
-    install_requires=['requests>=2.20.1', 'toml>=0.10.0']
+    install_requires=['requests>=2.20.1', 'toml>=0.10.0', 'boto3>=1.9.93']
 )


### PR DESCRIPTION
The SAMLAssertion string was too long to be passed to the command line on windows, so this call has been updated to use `boto3`. Further updates due to paths not being checked for `aws` by `subprocess` module.