### PR TITLE
add commandline arg for ARN/role

### DIFF
--- a/okta_aws/okta_aws.py
+++ b/okta_aws/okta_aws.py
@@ -68,6 +68,8 @@ class OktaAWS(object):
                             "applications in okta")
         parser.add_argument('--all', '-a', action='store_true',
                             help='Assume a role in all assigned accounts')
+        parser.add_argument('--role_arn', '-r',
+                            help='Role name or ARN to assume')
         parser.add_argument('--version', '-v', action='version',
                             version=__VERSION__,
                             help='Show version of okta_aws and exit')
@@ -225,7 +227,8 @@ class OktaAWS(object):
         """
         selected = None
         if len(arns) > 1:
-            role_arn = self.get_config('role_arn')
+            # Get role via config, but allow commandline override
+            role_arn = self.get_config('role_arn') or self.args.role_arn
             if role_arn is not None:
                 # First check to see if we configured a default role
                 logging.debug("Looking for configured role: %s", role_arn)


### PR DESCRIPTION
Add a command line arg (`-r`) to specify a default role or ARN, regardless of the config values.

<!--- Provide a short summary of your changes in the Title above -->

## Description
With many assigned applications in Okta, using `-a` to get credentials for all of them, you'd get prompted for which role to assign if a default wasn't in your config.  This makes things a little more script-friendly and provides an easy override for testing.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
